### PR TITLE
feature: Choose folder separately; insert embedded pdf link; bug fix

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -19,8 +19,6 @@ export function createCommands(plugin: XoppPlugin) {
             return true;
         }
     });
-    
-    
 
     plugin.addCommand({
         id: 'crate-new-xournalpp',
@@ -29,16 +27,6 @@ export function createCommands(plugin: XoppPlugin) {
             new createXoppFileModal(plugin.app, plugin)
                 .setTitle("Create a new Xournal++ note")
                 .open()
-        }
-    });
-
-    plugin.addCommand({
-        id: 'crate-new-xournalpp-in-folder',
-        name: 'Create a new note in a chosen folder',
-        callback: async () => {
-            new createXoppFileModal(plugin.app, plugin, "", null, "", true)
-            .setTitle("Create a new Xournal++ note in a chosen folder")
-            .open()
         }
     });
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,6 +20,8 @@ export function createCommands(plugin: XoppPlugin) {
         }
     });
     
+    
+
     plugin.addCommand({
         id: 'crate-new-xournalpp',
         name: 'Create a new note',
@@ -27,6 +29,16 @@ export function createCommands(plugin: XoppPlugin) {
             new createXoppFileModal(plugin.app, plugin)
                 .setTitle("Create a new Xournal++ note")
                 .open()
+        }
+    });
+
+    plugin.addCommand({
+        id: 'crate-new-xournalpp-in-folder',
+        name: 'Create a new note in a chosen folder',
+        callback: async () => {
+            new createXoppFileModal(plugin.app, plugin, "", null, "", true)
+            .setTitle("Create a new Xournal++ note in a chosen folder")
+            .open()
         }
     });
 
@@ -46,6 +58,16 @@ export function createCommands(plugin: XoppPlugin) {
         editorCallback: async (editor: Editor) => {
             new createXoppFileModal(plugin.app, plugin, "", editor, "PDF")
                 .setTitle("Create a new Xournal++ note and insert link")
+                .open()      
+        }
+    });
+
+    plugin.addCommand({
+        id: 'crate-new-xournalpp-and-link-embedded-pdf',
+        name: 'Create a new note and insert embedded PDF link',
+        editorCallback: async (editor: Editor) => {
+            new createXoppFileModal(plugin.app, plugin, "", editor, "embeddedPDF")
+                .setTitle("Create a new Xournal++ note and insert embedded link")
                 .open()      
         }
     });

--- a/src/fileExplorerFile.ts
+++ b/src/fileExplorerFile.ts
@@ -8,20 +8,36 @@ export function addOpenInXournalpp(plugin: XoppPlugin) {
     fileExplorers.forEach(fileExplorer => {
         let allFiles = (fileExplorer.view as any)?.fileItems;
 
-        const files:Array<Array<HTMLElement|TFile>> = [];
+        if (!allFiles) {
+            console.error("No file items found in file explorer.");
+            return;
+        }
+
+        const files: Array<Array<HTMLElement | TFile>> = [];
         Object.entries(allFiles).forEach(([filePath, value]) => {
             if (filePath.endsWith(".pdf")) {
-                let xoppFile = findCorrespondingXoppToPdf(filePath as string, plugin)
-                if (xoppFile) files.push([(value as any).tagEl as HTMLElement, xoppFile]);
+                let xoppFile = findCorrespondingXoppToPdf(filePath as string, plugin);
+                if (xoppFile) {
+                    const tagEl = (value as any).tagEl as HTMLElement;
+                    if (!tagEl) {
+                        console.error(`No tagEl found for file path: ${filePath}`);
+                    } else {
+                        files.push([tagEl, xoppFile]);
+                    }
+                }
             }
         });
 
         files.forEach(([div, file]: [HTMLElement, TFile]) => {
+            if (div) {
                 div.innerText = "X++";
                 div.classList.add("clickable-tag");
                 div.onclick = () => {
                     openXournalppFile(file, plugin);
-                }                                
-        })
-    })
+                };
+            } else {
+                console.error("Element is null for file:", file);
+            }
+        });
+    });
 }

--- a/src/fileExplorerFile.ts
+++ b/src/fileExplorerFile.ts
@@ -45,7 +45,6 @@ function applyXournalppTags(plugin: XoppPlugin) {
                         tagEl.onclick = () => {
                             openXournalppFile(xoppFile, plugin);
                         };
-                        console.log("TagEl successful for file:", filePath);
                     }
                 }
             }

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -1,68 +1,107 @@
-import { App, ButtonComponent, Editor, Modal, Setting, TextComponent } from "obsidian";
+import { App, ButtonComponent, Editor, FileSystemAdapter, Modal, Setting, TextComponent } from "obsidian";
 import { createXoppFile } from "./xoppActions";
 import XoppPlugin from "main";
 
 export class createXoppFileModal extends Modal {
     plugin: XoppPlugin;
     filePath: string;
-    editor: Editor|null;
+    editor: Editor | null;
     linksToInsert: string;
+    folderFlag: boolean;
 
-    constructor(app: App, plugin: XoppPlugin, path: string = "", editor: Editor|null = null, linksToInsert: string = "") {
+    constructor(app: App, plugin: XoppPlugin, filePath: string = "", editor: Editor | null = null, linksToInsert: string = "", folderFlag: boolean = false) {
         super(app);
         this.plugin = plugin as XoppPlugin;
-        this.filePath = path ? path + "/" : "";
+        this.filePath = filePath ? filePath + "/" : "";
         this.editor = editor;
         this.linksToInsert = linksToInsert;
+        this.folderFlag = folderFlag;
     }
 
     onOpen() {
         const { contentEl } = this;
-        let fileName: string;
+        let folderFlag = this.folderFlag;
+        let filePath = this.filePath;
 
-        let container = contentEl.createDiv({cls: 'new-file-modal-form'})
+        let container = contentEl.createDiv({ cls: 'new-file-modal-form' });
+
+        if (folderFlag) {
+            // Prompt for folder path if create in a specific folder is called
+            new TextComponent(container)
+                .setPlaceholder("Folder path")
+                .onChange((i) => {
+                    filePath = i;
+                    console.log("Folder path set to:", filePath);
+                })
+                .inputEl.addEventListener("keypress", (e) => {
+                    if (e.key === "Enter") {
+                        console.log("Enter key pressed for folder path");
+                        this.insertFileName(container, filePath);
+                    }
+                });
+
+            new ButtonComponent(container)
+                .setButtonText("Next")
+                .onClick(() => {
+                    console.log("Next button clicked for folder path");
+                    this.insertFileName(container, filePath);
+                });
+        } else {
+            // Prompt for file name directly if create in default folder is called
+            this.insertFileName(container, filePath);
+        }
+    }
+
+    insertFileName(container: HTMLDivElement, filePath: string) {
+        container.empty();
+
+        let fileName: string;
 
         new TextComponent(container)
             .setPlaceholder("File name")
-            .onChange((i) => fileName = i)
-            .inputEl.addEventListener("keypress", (e) => {
-                if (e.key === "Enter") this.submitInput(fileName)
+            .onChange((i) => {
+                fileName = i;
             })
+            .inputEl.addEventListener("keypress", (e) => {
+                if (e.key === "Enter") {
+                    this.submitInput(filePath, fileName);
+                }
+            });
 
         new ButtonComponent(container)
             .setButtonText("Create")
             .onClick(() => {
-                this.submitInput(fileName);
-            })
+                this.submitInput(filePath, fileName);
+            });
     }
 
-    
-    submitInput(path: string) {
-        path += ".xopp";
+    submitInput(filePath: string, fileName: string) {
+        fileName += ".xopp";
 
-        createXoppFile(this.plugin, this.filePath + path)
+        createXoppFile(this.plugin, `${filePath}/${fileName}`);
         this.close();
 
-        this.insertLink(path);
+        this.insertLink(filePath, fileName);
     }
 
-    insertLink(path: string) {
+    insertLink(filePath: string, fileName: string) {
         if (!this.editor) return;
 
-        let fileName = path.split("/")[path.split("/").length -1]
+        if (filePath === "") filePath = fileName;
 
-        let xoppLink = "[[" + path + "|" + fileName + "]]";
-        let pdfLink = "[[" + path.replace(".xopp", ".pdf") + "|" + fileName.replace(".xopp", ".pdf") + "]]";
+        fileName = fileName.replace(".xopp", "");
+        
+        let xoppLink = "[[" + filePath + "|" + fileName + "]]";
+        let pdfLink = "[[" + filePath.replace(".xopp", ".pdf") + "|" + fileName + "]]";
         let finalLink = xoppLink + " " + pdfLink;
 
-        console.log(this.linksToInsert)
-        
+        if (this.linksToInsert === "embeddedPDF") finalLink = "!" + pdfLink;
         if (this.linksToInsert === "PDF") finalLink = pdfLink;
         if (this.linksToInsert === "XOPP") finalLink = xoppLink;
 
         this.editor.replaceRange(finalLink, this.editor.getCursor());
     }
-    
+
     onClose() {
         const { contentEl } = this;
         contentEl.empty();

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -7,49 +7,38 @@ export class createXoppFileModal extends Modal {
     filePath: string;
     editor: Editor | null;
     linksToInsert: string;
-    folderFlag: boolean;
-
-    constructor(app: App, plugin: XoppPlugin, filePath: string = "", editor: Editor | null = null, linksToInsert: string = "", folderFlag: boolean = false) {
+    
+    constructor(app: App, plugin: XoppPlugin, filePath: string = "", editor: Editor | null = null, linksToInsert: string = "") {
         super(app);
         this.plugin = plugin as XoppPlugin;
         this.filePath = filePath ? filePath + "/" : "";
         this.editor = editor;
         this.linksToInsert = linksToInsert;
-        this.folderFlag = folderFlag;
     }
 
     onOpen() {
         const { contentEl } = this;
-        let folderFlag = this.folderFlag;
         let filePath = this.filePath;
 
         let container = contentEl.createDiv({ cls: 'new-file-modal-form' });
 
-        if (folderFlag) {
-            // Prompt for folder path if create in a specific folder is called
-            new TextComponent(container)
-                .setPlaceholder("Folder path")
-                .onChange((i) => {
-                    filePath = i;
-                    console.log("Folder path set to:", filePath);
-                })
-                .inputEl.addEventListener("keypress", (e) => {
-                    if (e.key === "Enter") {
-                        console.log("Enter key pressed for folder path");
-                        this.insertFileName(container, filePath);
-                    }
-                });
-
-            new ButtonComponent(container)
-                .setButtonText("Next")
-                .onClick(() => {
-                    console.log("Next button clicked for folder path");
+        new TextComponent(container)
+            .setPlaceholder("Folder path")
+            .onChange((i) => {
+                filePath = i;
+            })
+            .inputEl.addEventListener("keypress", (e) => {
+                if (e.key === "Enter") {
                     this.insertFileName(container, filePath);
-                });
-        } else {
-            // Prompt for file name directly if create in default folder is called
-            this.insertFileName(container, filePath);
-        }
+                }
+            });
+
+        new ButtonComponent(container)
+            .setButtonText("Next")
+            .onClick(() => {
+                this.insertFileName(container, filePath);
+            });
+
     }
 
     insertFileName(container: HTMLDivElement, filePath: string) {

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -67,21 +67,26 @@ export class createXoppFileModal extends Modal {
     submitInput(filePath: string, fileName: string) {
         fileName += ".xopp";
 
-        createXoppFile(this.plugin, `${filePath}/${fileName}`);
+        createXoppFile(this.plugin, filePath === "" ? fileName : `${filePath}/${fileName}`);
         this.close();
 
         this.insertLink(filePath, fileName);
     }
 
     insertLink(filePath: string, fileName: string) {
-        if (!this.editor) return;
+        if (!this.editor) {
+            return;
+        }
 
-        if (filePath === "") filePath = fileName;
+        const defaultNewFilePath = this.plugin.settings.defaultNewFilePath;
+
+        if (filePath !== "") filePath = filePath + "/";
+        else filePath = defaultNewFilePath ? defaultNewFilePath + "/" : "/";
 
         fileName = fileName.replace(".xopp", "");
         
-        let xoppLink = "[[" + filePath + "|" + fileName + "]]";
-        let pdfLink = "[[" + filePath.replace(".xopp", ".pdf") + "|" + fileName + "]]";
+        let xoppLink = "[[" + filePath + fileName + ".xopp" + "|" + fileName + "]]";
+        let pdfLink = "[[" + filePath + fileName + ".pdf" + "|" + fileName + "]]";
         let finalLink = xoppLink + " " + pdfLink;
 
         if (this.linksToInsert === "embeddedPDF") finalLink = "!" + pdfLink;

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -23,7 +23,7 @@ export class createXoppFileModal extends Modal {
         let container = contentEl.createDiv({ cls: 'new-file-modal-form' });
 
         new TextComponent(container)
-            .setPlaceholder("Folder path")
+            .setPlaceholder("Folder path (default if empty)")
             .onChange((i) => {
                 filePath = i;
             })
@@ -43,20 +43,23 @@ export class createXoppFileModal extends Modal {
 
     insertFileName(container: HTMLDivElement, filePath: string) {
         container.empty();
-
+    
         let fileName: string;
-
-        new TextComponent(container)
+    
+        const textComponent = new TextComponent(container)
             .setPlaceholder("File name")
             .onChange((i) => {
                 fileName = i;
-            })
-            .inputEl.addEventListener("keypress", (e) => {
-                if (e.key === "Enter") {
-                    this.submitInput(filePath, fileName);
-                }
             });
-
+    
+        textComponent.inputEl.focus();
+    
+        textComponent.inputEl.addEventListener("keypress", (e) => {
+            if (e.key === "Enter") {
+                this.submitInput(filePath, fileName);
+            }
+        });
+    
         new ButtonComponent(container)
             .setButtonText("Create")
             .onClick(() => {

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -1,4 +1,4 @@
-import { App, ButtonComponent, Editor, FileSystemAdapter, Modal, Setting, TextComponent } from "obsidian";
+import { App, ButtonComponent, Editor, Modal, TextComponent } from "obsidian";
 import { createXoppFile } from "./xoppActions";
 import XoppPlugin from "main";
 


### PR DESCRIPTION
- Behavior of new xournalpp changed: first, enter the folder path (if empty => default), then the file name
- Changed path variable naming for easier distinction between path, file name, and file path _(dev)_
- Added new command: insert embedded PDF
- **Bug fix**: `.pdf` didn't change immediately to `.x++` once the app started and threw an error. Now changes right away when the app starts

My first Obsidian contribution, but I believe I've done some useful stuff :)
Let me know if anything's buggy or if changes need to be made