### PR TITLE
Fix #14 Creating all pdfs on startup instead of only modified ones

### DIFF
--- a/src/listeners.ts
+++ b/src/listeners.ts
@@ -7,7 +7,6 @@ import { addOpenInXournalpp } from "./fileExplorerFile";
 import { exportXoppToPDF } from "./xopp2pdf";
 
 export function setupListeners(plugin: XoppPlugin) {
-    initialLoad(plugin);
 
     // on startup
     plugin.registerEvent(plugin.app.workspace.on("layout-change", () => {
@@ -31,19 +30,38 @@ export function setupListeners(plugin: XoppPlugin) {
     plugin.registerEvent(plugin.app.vault.on("modify", (file: TFile) => {
         if (file.extension === "xopp" && plugin.settings.autoExport) exportXoppToPDF(plugin, [file.path], false)
     }))
+    plugin.app.workspace.onLayoutReady(() => {
+    initialLoad(plugin);
     plugin.registerEvent(plugin.app.vault.on("create", (file: TFile) => {
         if (file.extension === "xopp" && plugin.settings.autoExport) exportXoppToPDF(plugin, [file.path], false)
     }))
+    });
 }
 
 function initialLoad(plugin: XoppPlugin) {
     if (plugin.settings.autoExport) {
         let files = plugin.app.vault.getFiles();
-        files = files.filter(file => file.extension === "xopp");
-        let filePaths = files.map(file => file.path)
-        exportXoppToPDF(plugin, filePaths, false)
+        let xopp_files = files.filter(file => file.extension === "xopp");
+        let pdf_files = files.filter(file => file.extension === "pdf");
+
+        let filePaths = [];
+        for (const xopp_file of xopp_files) {
+                let pdf_file = pdf_files.find(pdf => pdf.path === xopp_file.path.replace(".xopp", ".pdf")) || false;
+                let xopp_is_newer = false;
+                if (pdf_file) {
+                    xopp_is_newer = xopp_file.stat.mtime > pdf_file.stat.mtime;
+                    console.log('the pdf exists, xopp_greater: ${xopp_is_newer}, xopp time: ${xopp_file.stat.mtime}, pdf time: ${pdf_file.stat.mtime}')
+                }
+                // Add the file path to the list if PDF doesn't exist or XOPP is newer
+                if (!pdf_file || xopp_is_newer) {
+                    filePaths.push(xopp_file.path);
+                }
+        }
+        // Only export if there are files to update
+        if (filePaths.length > 0) {
+            exportXoppToPDF(plugin, filePaths, false);
+        }
     }
-    
     addCreateXournalppNavIcon(plugin);
     addOpenInXournalpp(plugin);
 }

--- a/src/listeners.ts
+++ b/src/listeners.ts
@@ -50,18 +50,19 @@ function initialLoad(plugin: XoppPlugin) {
                 let xopp_is_newer = false;
                 if (pdf_file) {
                     xopp_is_newer = xopp_file.stat.mtime > pdf_file.stat.mtime;
-                    console.log('the pdf exists, xopp_greater: ${xopp_is_newer}, xopp time: ${xopp_file.stat.mtime}, pdf time: ${pdf_file.stat.mtime}')
                 }
                 // Add the file path to the list if PDF doesn't exist or XOPP is newer
                 if (!pdf_file || xopp_is_newer) {
                     filePaths.push(xopp_file.path);
                 }
         }
-        // Only export if there are files to update
+        
         if (filePaths.length > 0) {
             exportXoppToPDF(plugin, filePaths, false);
         }
     }
+    
     addCreateXournalppNavIcon(plugin);
     addOpenInXournalpp(plugin);
+
 }


### PR DESCRIPTION
I tested a few conditions:
with the plugin on: creating a new file, modifying an existing file

with the plugin off: creating a new file, modifying a file, then switching the plugin on

with obsidian off: creating a new file, modifying a file, then starting the obsidian vault.

I needed to move initialLoad and the 'on "create" event' inside of the onLayoutReady condition because:
-create was making new pdf files for all xopps upon opening the vault (as per its description, "This is also called when the vault is first loaded for each existing file")
-the initialLoad modifications required this so that modified xopp's would have their pdf's created upon starting a vault