### PR TITLE
Fix #13 - Fix user-set xournalpp command not working when consisting of more than one parameter (e.g. flatpak-spawn)

### DIFF
--- a/src/checks.ts
+++ b/src/checks.ts
@@ -12,7 +12,7 @@ export async function checkXoppSetup(plugin: XoppPlugin): Promise<string> {
 
     if (userPath) {
         try {
-			if(!userPath.startsWith('"') || !userPath.endsWith('"')) userPath =`"${userPath}"`;
+			//if(!userPath.startsWith('"') || !userPath.endsWith('"')) userPath =`"${userPath}"`;
 			await executeCommand(userPath + versionCmd);
         	return userPath;
 		} catch (error) {

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -12,7 +12,6 @@ export async function checkXoppSetup(plugin: XoppPlugin): Promise<string> {
 
     if (userPath) {
         try {
-			//if(!userPath.startsWith('"') || !userPath.endsWith('"')) userPath =`"${userPath}"`;
 			await executeCommand(userPath + versionCmd);
         	return userPath;
 		} catch (error) {


### PR DESCRIPTION
The code for opening a Xournal++ file tries to read the user-set command as a single quoted string so a single file. When using the (default) Flatpak version on Linux, you need to use the "flatpak-spawn" command to get out of the sandbox, which will then be read as a part of the filename in bash.

Issue discussed in https://github.com/jonjampen/obsidian-xournalpp/issues/13

Conflicts with https://github.com/jonjampen/obsidian-xournalpp/commit/5bfacc49eda8ebe376624302592518882f827705 (Issue https://github.com/jonjampen/obsidian-xournalpp/issues/11) but fixes default behavior, if there are spaces in the user path, you can add quotes yourself.