### PR TITLE
Add confirmation alert & auto-export of XOPP to PDF immediately when the setting enabled

### DIFF
--- a/src/XoppSettingsTab.ts
+++ b/src/XoppSettingsTab.ts
@@ -1,5 +1,7 @@
 import XoppPlugin from "main";
 import { App, Setting, PluginSettingTab } from "obsidian";
+import ConfirmationModal from "./modals/ConfirmationModal";
+import { exportAllXoppToPDF } from "src/xopp2pdf";
 
 export class XoppSettingsTab extends PluginSettingTab {
     plugin: XoppPlugin;
@@ -15,16 +17,30 @@ export class XoppSettingsTab extends PluginSettingTab {
         containerEl.empty();
     
         new Setting(containerEl)
-            .setName("Auto export Xournal++ files")
-            .setDesc("Automatically export Xournal++ files to PDF upon modification.")
-            .addToggle((toggle) => {
-                toggle
-                    .setValue(this.plugin.settings.autoExport)
-                    .onChange(async (value) => {
-                        this.plugin.settings.autoExport = value;
+    .setName("Auto export Xournal++ files")
+    .setDesc("Automatically export Xournal++ files to PDF upon modification.")
+    .addToggle((toggle) => {
+        toggle
+            .setValue(this.plugin.settings.autoExport)
+            .onChange(async (value) => {
+                if (value) {
+                    const confirmationModal = new ConfirmationModal(this.app, async () => {
+                        this.plugin.settings.autoExport = true;
                         await this.plugin.saveSettings();
-                    })
+                        toggle.setValue(true);
+                    
+                        exportAllXoppToPDF(this.plugin);
+                    }, async () => {
+                        toggle.setValue(false); 
+                    });
+                    confirmationModal.open();
+                } else {
+                    this.plugin.settings.autoExport = false;
+                    await this.plugin.saveSettings();
+                    toggle.setValue(false);
+                }
             });
+    });
 
         new Setting(containerEl)
             .setName("Xournal++ installation path")
@@ -70,3 +86,5 @@ export class XoppSettingsTab extends PluginSettingTab {
     }
   
 }
+
+

--- a/src/XoppSettingsTab.ts
+++ b/src/XoppSettingsTab.ts
@@ -24,6 +24,7 @@ export class XoppSettingsTab extends PluginSettingTab {
             .setValue(this.plugin.settings.autoExport)
             .onChange(async (value) => {
                 if (value) {
+                    const initialValue = this.plugin.settings.autoExport;
                     const confirmationModal = new ConfirmationModal(this.app, async () => {
                         this.plugin.settings.autoExport = true;
                         await this.plugin.saveSettings();
@@ -31,8 +32,15 @@ export class XoppSettingsTab extends PluginSettingTab {
                     
                         exportAllXoppToPDF(this.plugin);
                     }, async () => {
+                        this.plugin.settings.autoExport = false;
+                        await this.plugin.saveSettings();
                         toggle.setValue(false); 
-                    });
+                    }, initialValue, toggle);
+                    confirmationModal.onClose = () => {
+                        if (!confirmationModal.confirmed) {
+                            toggle.setValue(false);
+                        }
+                    };
                     confirmationModal.open();
                 } else {
                     this.plugin.settings.autoExport = false;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,7 +1,7 @@
 import { Editor, TFile } from "obsidian";
 import { deleteXoppAndPdf, findCorrespondingXoppToPdf, openXournalppFile, renameXoppFile } from "./xoppActions";
 import XoppPlugin from "main";
-import { exportXoppToPDF } from "./xopp2pdf";
+import { exportAllXoppToPDF, exportXoppToPDF } from "./xopp2pdf";
 import CreateXoppModalManager from "./CreateXoppModalManager";
 import RenameModal from "./modals/RenameModal";
 import SearchXoppModal from "./modals/SearchXoppModal";
@@ -66,10 +66,7 @@ export function createCommands(plugin: XoppPlugin) {
         id: "export-xournalpp-to-pdf",
         name: "Export all notes to PDF",
         callback: async () => {
-            let files = plugin.app.vault.getFiles();
-            files = files.filter((file) => file.extension === "xopp");
-            let filePaths = files.map((file) => file.path);
-            exportXoppToPDF(plugin, filePaths);
+            exportAllXoppToPDF(plugin);
         },
     });
 

--- a/src/modals/ConfirmationModal.ts
+++ b/src/modals/ConfirmationModal.ts
@@ -3,24 +3,21 @@ import { App, Modal } from "obsidian";
 export default class ConfirmationModal extends Modal {
     onConfirm: () => Promise<void>;
     onReject: () => Promise<void>;
+    private initialValue: boolean;
+    private toggle: any;
+    public confirmed: boolean = false;
 
-    constructor(app: App, onConfirm: () => Promise<void>, onReject: () => Promise<void>) { 
+    constructor(app: App, onConfirm: () => Promise<void>, onReject: () => Promise<void>, initialValue: boolean, toggle: any) {
         super(app);
         this.onConfirm = onConfirm;
         this.onReject = onReject;
+        this.initialValue = initialValue;
+        this.toggle = toggle
     }
 
     onOpen() {
         super.onOpen();
         const { contentEl } = this;
-
-        this.modalEl.focus();
-        this.modalEl.addEventListener("keydown", (event: KeyboardEvent) => {
-            if (event.key === "Escape") {
-                this.onReject();
-                this.close();
-            }
-        });
 
         contentEl.createEl("h2", { text: "Enable Auto Export?" });
         contentEl.createEl("p", {
@@ -31,6 +28,7 @@ export default class ConfirmationModal extends Modal {
 
         const confirmButton = buttonContainer.createEl("button", { text: "Yes" });
         confirmButton.addEventListener("click", async () => {
+            this.confirmed = true;
             await this.onConfirm();
             this.close();
         });
@@ -43,6 +41,7 @@ export default class ConfirmationModal extends Modal {
     }
 
     onClose() {
+        super.onClose();
         const { contentEl } = this;
         contentEl.empty();
     }

--- a/src/modals/ConfirmationModal.ts
+++ b/src/modals/ConfirmationModal.ts
@@ -1,0 +1,49 @@
+import { App, Modal } from "obsidian";
+
+export default class ConfirmationModal extends Modal {
+    onConfirm: () => Promise<void>;
+    onReject: () => Promise<void>;
+
+    constructor(app: App, onConfirm: () => Promise<void>, onReject: () => Promise<void>) { 
+        super(app);
+        this.onConfirm = onConfirm;
+        this.onReject = onReject;
+    }
+
+    onOpen() {
+        super.onOpen();
+        const { contentEl } = this;
+
+        this.modalEl.focus();
+        this.modalEl.addEventListener("keydown", (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                this.onReject();
+                this.close();
+            }
+        });
+
+        contentEl.createEl("h2", { text: "Enable Auto Export?" });
+        contentEl.createEl("p", {
+            text: "Enabling auto export might automatically overwrite any same-named files. Do you want to proceed?",
+        });
+
+        const buttonContainer = contentEl.createDiv({ cls: "modal-button-container" });
+
+        const confirmButton = buttonContainer.createEl("button", { text: "Yes" });
+        confirmButton.addEventListener("click", async () => {
+            await this.onConfirm();
+            this.close();
+        });
+
+        const cancelButton = buttonContainer.createEl("button", { text: "No" });
+        cancelButton.addEventListener("click", () => {
+            this.onReject();
+            this.close();
+        });
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+}

--- a/src/xopp2pdf.ts
+++ b/src/xopp2pdf.ts
@@ -37,3 +37,10 @@ export function exportXoppToPDF(plugin: XoppPlugin, filePaths: Array<string>, no
     
     if (notify) new Notice("Exported all Xournal++ notes successfully.")
 }
+
+export function exportAllXoppToPDF(plugin: XoppPlugin) {
+  let files = plugin.app.vault.getFiles();
+  files = files.filter((file) => file.extension === "xopp");
+  let filePaths = files.map((file) => file.path);
+  exportXoppToPDF(plugin, filePaths);
+}


### PR DESCRIPTION
- Auto-export now triggers immediately on enabling (no reload needed)
- Confirmation modal warns of possible PDF overwrite before proceeding
- Choosing “No” or pressing Esc cancels without changing the setting

