### PR TITLE
chore: change plugin name to adhere to new naming convention

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-    "id": "xournalpp",
-    "name": "Xournal++",
-    "version": "1.1.2",
-    "minAppVersion": "1.5.12",
-    "description": "Integration with Xournal++ for handwritten notes and annotations.",
-    "author": "Jon Jampen",
-    "authorUrl": "https://jonjampen.ch",
-    "fundingUrl": "https://buymeacoffee.com/jonjampen",
-    "isDesktopOnly": true
+	"id": "xournalpp",
+	"name": "Xournalpp",
+	"version": "1.1.2",
+	"minAppVersion": "1.5.12",
+	"description": "Integration with Xournal++ for handwritten notes and annotations.",
+	"author": "Jon Jampen",
+	"authorUrl": "https://jonjampen.ch",
+	"fundingUrl": "https://buymeacoffee.com/jonjampen",
+	"isDesktopOnly": true
 }


### PR DESCRIPTION
The Obsidian naming standards have changed, and special symbols are no longer allowed.

Therefore the plugin name will be changed from `Xournal++` to `Xournalpp`.