### PR TITLE
fix: add delay for pdf conversion to stop conversion on incomplete files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "xournalpp",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "xournalpp",
-            "version": "1.1.2",
+            "version": "1.2.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/src/core/listeners.ts
+++ b/src/core/listeners.ts
@@ -34,10 +34,24 @@ export function setupListeners(plugin: XoppPlugin) {
         })
     );
 
+    const exportDebounceTimers = new Map<string, number | NodeJS.Timeout>();
+
+    const debouncedExport = (filePath: string) => {
+        const existing = exportDebounceTimers.get(filePath);
+        if (existing) window.clearTimeout(existing as number);
+        exportDebounceTimers.set(
+            filePath,
+            window.setTimeout(() => {
+                exportDebounceTimers.delete(filePath);
+                void exportXoppToPDF(plugin, [filePath], false);
+            }, 1000)
+        );
+    };
+
     plugin.registerEvent(
         plugin.app.vault.on("modify", (file: TFile) => {
             if (file.extension === "xopp" && plugin.settings.autoExport) {
-                void exportXoppToPDF(plugin, [file.path], false);
+                debouncedExport(file.path);
             }
         })
     );
@@ -46,7 +60,7 @@ export function setupListeners(plugin: XoppPlugin) {
         plugin.registerEvent(
             plugin.app.vault.on("create", (file: TFile) => {
                 if (file.extension === "xopp" && plugin.settings.autoExport) {
-                    void exportXoppToPDF(plugin, [file.path], false);
+                    debouncedExport(file.path);
                 }
             })
         );

--- a/src/utils/xopp-to-pdf.ts
+++ b/src/utils/xopp-to-pdf.ts
@@ -30,10 +30,25 @@ export async function exportXoppToPDF(plugin: XoppPlugin, filePaths: Array<strin
             const pdfFilePath = xoppFilePath.replace(".xopp", ".pdf");
             const command = `${path} --create-pdf="${pdfFilePath}" "${xoppFilePath}"`;
 
-            try {
-                await execPromise(command);
-            } catch (error) {
-                console.error(`Error converting Xournal++ to PDF (${filePath}):`, error);
+            const maxRetries = 3;
+            let success = false;
+            let lastError: unknown;
+
+            for (let attempt = 1; attempt <= maxRetries; attempt++) {
+                try {
+                    await execPromise(command);
+                    success = true;
+                    break;
+                } catch (error) {
+                    lastError = error;
+                    if (attempt < maxRetries) {
+                        await new Promise((resolve) => window.setTimeout(resolve, 500));
+                    }
+                }
+            }
+
+            if (!success) {
+                console.error(`Error converting Xournal++ to PDF (${filePath}):`, lastError);
                 hasErrors = true;
             }
         });


### PR DESCRIPTION
## What this PR does

This PR fixes errors displayed since `v1.2.0`. It was caused by immediate conversion to `.pdf`, even though Xournal++ had not yet finished writing the `.xopp` file. This error was already present; just after the update, the error message was actually displayed and not just suppressed.

## The error
```
Error converting Xournal++ to PDF ([file]: Command failed: xournalpp --create-pdf="[file path]" "[file path]"
xopp-Message: 19:33:55.645: Document is not complete (maybe the end is cut off?)
``` 

## The fix

Wait for 1 second and retry 3 times if an error occurs.