### PR TITLE
perf: implement file writing via temporary file to reduce vault crashes

### DIFF
--- a/src/utils/xopp-to-pdf.ts
+++ b/src/utils/xopp-to-pdf.ts
@@ -1,10 +1,14 @@
 import { FileSystemAdapter, Notice } from "obsidian";
 import { exec } from "child_process";
+import { rename, unlink } from "fs/promises";
 import XoppPlugin from "src/main";
 import { checkXoppSetup } from "../core/environment-checks";
 import { promisify } from "util";
 
 const execPromise = promisify(exec);
+
+const activeExports = new Set<string>();
+const pendingExports = new Set<string>();
 
 export async function exportXoppToPDF(plugin: XoppPlugin, filePaths: Array<string>, notify = true): Promise<void> {
     const fs = plugin.app.vault.adapter;
@@ -21,14 +25,29 @@ export async function exportXoppToPDF(plugin: XoppPlugin, filePaths: Array<strin
     const vaultPath = fs.getBasePath();
     let hasErrors = false;
 
+    const pathsToProcess: string[] = [];
+    for (const fp of filePaths) {
+        if (activeExports.has(fp)) {
+            pendingExports.add(fp);
+        } else {
+            activeExports.add(fp);
+            pathsToProcess.push(fp);
+        }
+    }
+
+    if (pathsToProcess.length === 0) {
+        return;
+    }
+
     // Process paths in batches of 5 to prevent system process exhaustion
     const concurrencyLimit = 5;
-    for (let i = 0; i < filePaths.length; i += concurrencyLimit) {
-        const batch = filePaths.slice(i, i + concurrencyLimit);
+    for (let i = 0; i < pathsToProcess.length; i += concurrencyLimit) {
+        const batch = pathsToProcess.slice(i, i + concurrencyLimit);
         const batchPromises = batch.map(async (filePath) => {
             const xoppFilePath = vaultPath + "/" + filePath;
-            const pdfFilePath = xoppFilePath.replace(".xopp", ".pdf");
-            const command = `${path} --create-pdf="${pdfFilePath}" "${xoppFilePath}"`;
+            const pdfFilePath = xoppFilePath.replace(/\.xopp$/i, ".pdf");
+            const tempPdfFilePath = `${pdfFilePath}.tmp`;
+            const command = `${path} --create-pdf="${tempPdfFilePath}" "${xoppFilePath}"`;
 
             const maxRetries = 3;
             let success = false;
@@ -37,10 +56,12 @@ export async function exportXoppToPDF(plugin: XoppPlugin, filePaths: Array<strin
             for (let attempt = 1; attempt <= maxRetries; attempt++) {
                 try {
                     await execPromise(command);
+                    await rename(tempPdfFilePath, pdfFilePath).catch(() => {});
                     success = true;
                     break;
                 } catch (error) {
                     lastError = error;
+                    await unlink(tempPdfFilePath).catch(() => {});
                     if (attempt < maxRetries) {
                         await new Promise((resolve) => window.setTimeout(resolve, 500));
                     }
@@ -50,6 +71,13 @@ export async function exportXoppToPDF(plugin: XoppPlugin, filePaths: Array<strin
             if (!success) {
                 console.error(`Error converting Xournal++ to PDF (${filePath}):`, lastError);
                 hasErrors = true;
+            }
+
+            activeExports.delete(filePath);
+
+            if (pendingExports.has(filePath)) {
+                pendingExports.delete(filePath);
+                void exportXoppToPDF(plugin, [filePath], false);
             }
         });
         await Promise.all(batchPromises);

--- a/tests/utils/xopp-to-pdf.test.ts
+++ b/tests/utils/xopp-to-pdf.test.ts
@@ -9,6 +9,15 @@ vi.mock("src/core/environment-checks", () => ({
     checkXoppSetup: vi.fn(),
 }));
 
+vi.mock("fs/promises", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("fs/promises")>();
+    return {
+        ...actual,
+        rename: vi.fn().mockResolvedValue(undefined),
+        unlink: vi.fn().mockResolvedValue(undefined),
+    };
+});
+
 describe("xopp-to-pdf", () => {
     let mockPlugin: XoppPlugin;
     let mockAdapter: obsidian.FileSystemAdapter;
@@ -67,7 +76,7 @@ describe("xopp-to-pdf", () => {
         await exportXoppToPDF(mockPlugin, ["notes/lecture.xopp"]);
 
         expect(exec).toHaveBeenCalledWith(
-            'xournalpp --create-pdf="/mocked/vault/path/notes/lecture.pdf" "/mocked/vault/path/notes/lecture.xopp"',
+            'xournalpp --create-pdf="/mocked/vault/path/notes/lecture.pdf.tmp" "/mocked/vault/path/notes/lecture.xopp"',
             expect.any(Function)
         );
         expect(noticeSpy).toHaveBeenCalledWith("Exported all Xournal++ notes successfully.");
@@ -133,11 +142,11 @@ describe("xopp-to-pdf", () => {
 
         expect(exec).toHaveBeenCalledTimes(2);
         expect(exec).toHaveBeenCalledWith(
-            'xournalpp --create-pdf="/mocked/vault/path/note1.pdf" "/mocked/vault/path/note1.xopp"',
+            'xournalpp --create-pdf="/mocked/vault/path/note1.pdf.tmp" "/mocked/vault/path/note1.xopp"',
             expect.any(Function)
         );
         expect(exec).toHaveBeenCalledWith(
-            'xournalpp --create-pdf="/mocked/vault/path/folder/note3.pdf" "/mocked/vault/path/folder/note3.xopp"',
+            'xournalpp --create-pdf="/mocked/vault/path/folder/note3.pdf.tmp" "/mocked/vault/path/folder/note3.xopp"',
             expect.any(Function)
         );
         expect(noticeSpy).toHaveBeenCalledWith("Exported all Xournal++ notes successfully.");


### PR DESCRIPTION
## What this PR does

Fixes an issue where saving .xopp files while previewing their generated PDF in Obsidian causes vault freezes, high CPU usage, or InvalidPDFException errors due to reading incomplete PDFs mid-write.

## Solution

`xournalpp --create-pdf` now exports to a temporary file (`filename.pdf.tmp`), which is ignored by Obsidian's PDF viewer. Once rendering finishes, fs.rename atomically replaces `filename.pdf`, ensuring Obsidian only loads 100% complete PDFs.
